### PR TITLE
Улучшенное взаимодействие с API текстовых гизмосов

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ DebugX.Draw(duration, color).*Gizmo Function*(...);
 ### Unity-пакет
 Поддерживается установка в виде Unity-пакета через добавление [в PackageManager](https://docs.unity3d.com/2023.2/Documentation/Manual/upm-ui-giturl.html) или ручного добавления в `Packages/manifest.json` этого git-URL: 
 ```
-https://github.com/DCFApixels/DebugX.git
+https://github.com/DCFApixels/Unity-DebugX
 ```
 ### В виде исходников
 Пакет так же может быть добавлен в проект в виде исходников.

--- a/Runtime/Gizmos/DebugX.base.cs
+++ b/Runtime/Gizmos/DebugX.base.cs
@@ -222,58 +222,6 @@ namespace DCFApixels
             }
             #endregion
 
-            #region Text
-            [IN(LINE)] public DrawHandler Text(Vector3 position, object text) => Gizmo(new TextGizmo(position, text));
-            private readonly struct TextGizmo : IGizmo<TextGizmo>
-            {
-                public readonly Vector3 Position;
-                public readonly string Text;
-                [IN(LINE)]
-                public TextGizmo(Vector3 position, object text)
-                {
-                    Position = position;
-                    Text = text.ToString();
-                }
-                public IGizmoRenderer<TextGizmo> RegisterNewRenderer() { return new Renderer(); }
-
-                #region Renderer
-                private class Renderer : IGizmoRenderer_UnityGizmos<TextGizmo>
-                {
-                    private static GUIStyle _labelStyle;
-                    private static GUIContent _labelDummy;
-                    public int ExecuteOrder => default(UnlitMat).GetExecuteOrder();
-                    public bool IsStaticRender => false;
-                    public void Prepare(Camera camera, GizmosList<TextGizmo> list) { }
-                    public void Render(Camera camera, GizmosList<TextGizmo> list, CommandBuffer cb) { }
-                    public void Render_UnityGizmos(Camera camera, GizmosList<TextGizmo> list)
-                    {
-#if UNITY_EDITOR
-                        Color defaultColor = GUI.color;
-                        if (_labelStyle == null || _labelDummy == null)
-                        {
-                            _labelStyle = GUI.skin.label;
-                            _labelStyle.richText = false;
-                            _labelDummy = new GUIContent();
-                        }
-                        Handles.BeginGUI();
-                        foreach (ref readonly var item in list)
-                        {
-                            GUI.color = item.Color * GlobalColor;
-                            _labelDummy.text = item.Value.Text;
-                            if (!(HandleUtility.WorldToGUIPointWithDepth(item.Value.Position).z < 0f))
-                            {
-                                GUI.Label(HandleUtility.WorldPointToSizedRect(item.Value.Position, _labelDummy, _labelStyle), _labelDummy, _labelStyle);
-                            }
-                        }
-                        Handles.EndGUI();
-                        GUI.color = defaultColor;
-#endif
-                    }
-                }
-                #endregion
-            }
-            #endregion
-
             // Base Renderers
 
             #region MeshRendererBase

--- a/Runtime/Gizmos/DebugX.text.cs
+++ b/Runtime/Gizmos/DebugX.text.cs
@@ -61,7 +61,7 @@ namespace DCFApixels {
                 }
 
                 /// <summary>
-                /// Should be called once after the app domain is cleared.
+                /// Texture should be set once after the app domain is cleared.
                 /// </summary>
                 private void CheckTextureInstance() {
                     if (_backgroundTexture != null) {
@@ -141,9 +141,8 @@ namespace DCFApixels {
                         float GetCameraZoom() {
                             const float DEFAULT_ZOOM = 1f;
                         
-                            var localCamera = GetCurrentCamera();
-                            if (localCamera != null) {
-                                return localCamera.orthographicSize;
+                            if (camera != null) {
+                                return camera.orthographicSize;
                             }
                             
                             var currentDrawingSceneView = SceneView.currentDrawingSceneView;
@@ -152,7 +151,7 @@ namespace DCFApixels {
                                 return DEFAULT_ZOOM;
                             }
                             
-                            localCamera = currentDrawingSceneView.camera;
+                            var localCamera = currentDrawingSceneView.camera;
                                 
                             if (localCamera != null) {
                                 return localCamera.orthographicSize;

--- a/Runtime/Gizmos/DebugX.text.cs
+++ b/Runtime/Gizmos/DebugX.text.cs
@@ -153,7 +153,7 @@ namespace DCFApixels {
                             
                             localCamera = currentDrawingSceneView.camera;
                                 
-                            if (camera != null) {
+                            if (localCamera != null) {
                                 return localCamera.orthographicSize;
                             }
 

--- a/Runtime/Gizmos/DebugX.text.cs
+++ b/Runtime/Gizmos/DebugX.text.cs
@@ -91,8 +91,9 @@ namespace DCFApixels {
                         Color defaultColor = GUI.color;
                         if (_labelStyle == null || _labelDummy == null)
                         {
-                            _labelStyle = GUI.skin.label;
-                            _labelStyle.richText = false;
+                            _labelStyle = new GUIStyle(GUI.skin.label) {
+                                richText = false
+                            };
                             _labelDummy = new GUIContent();
                         }
 

--- a/Runtime/Gizmos/DebugX.text.cs
+++ b/Runtime/Gizmos/DebugX.text.cs
@@ -1,0 +1,253 @@
+﻿using DCFApixels.DebugXCore;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace DCFApixels {
+    using IN = System.Runtime.CompilerServices.MethodImplAttribute;
+    
+    public static partial class DebugX {
+        public readonly partial struct DrawHandler {
+            #region Text
+
+            /// <summary>
+            /// Draw text at the world position.
+            /// Can pass any object where ToString() will be called.
+            /// </summary>
+            /// <param name="position">World position.</param>
+            /// <param name="text">String or any other object.</param>
+            [IN(LINE)] public DrawHandler Text(Vector3 position, object text) => Gizmo(new TextGizmo(new TextBuilder(position, text)));
+
+            /// <summary>
+            /// Draw text at the world position.
+            /// Can pass any object where ToString() will be called.
+            /// </summary>
+            /// <param name="position">World position.</param>
+            /// <param name="text">String or any other object.</param>
+            /// <param name="fontSize">Text font size.</param>
+            [IN(LINE)] public DrawHandler Text(Vector3 position, object text, int fontSize) => Gizmo(new TextGizmo(new TextBuilder(position, text, fontSize)));
+            
+            /// <summary>
+            /// Draw text at the world position.
+            /// Can pass any object where ToString() will be called.
+            /// </summary>
+            /// <param name="position">World position.</param>
+            /// <param name="text">String or any other object.</param>
+            /// <param name="fontSize">Text font size.</param>
+            /// <param name="textAnchor">Text alignment.</param>
+            [IN(LINE)] public DrawHandler Text(Vector3 position, object text, int fontSize, TextAnchor textAnchor) => Gizmo(new TextGizmo(new TextBuilder(position, text, fontSize, textAnchor)));
+            
+            /// <summary>
+            /// Use text builder to pass more details about how text-gizmo should be drawn.
+            /// </summary>
+            /// <param name="textBuilder">Settings with a builder pattern.</param>
+            [IN(LINE)] public DrawHandler Text(TextBuilder textBuilder) => Gizmo(new TextGizmo(textBuilder));
+            
+            private readonly struct TextGizmo : IGizmo<TextGizmo> {
+                private const int BACKGROUND_TEXTURE_WIDTH = 2;
+                private const int BACKGROUND_TEXTURE_HEIGHT = 2;
+                private const int BACKGROUND_TEXTURE_PIXELS_COUNT = BACKGROUND_TEXTURE_WIDTH * BACKGROUND_TEXTURE_HEIGHT;
+                
+                // TODO: Normally Texture2D should be destroyed when not needed anymore. Though it will live through entire app lifetime. What about editor?
+                private static Texture2D _backgroundTexture;
+                private static Color32[] _backgroundTexturePixels;
+                public readonly TextBuilder TextBuilderInstance;
+                [IN(LINE)]
+                public TextGizmo(TextBuilder textBuilder) {
+                    TextBuilderInstance = textBuilder;
+                    CheckTextureInstance();
+                }
+
+                /// <summary>
+                /// Should be called once after the app domain is cleared.
+                /// </summary>
+                private void CheckTextureInstance() {
+                    if (_backgroundTexture != null) {
+                        return;
+                    }
+                    
+                    _backgroundTexture = new Texture2D(BACKGROUND_TEXTURE_WIDTH, BACKGROUND_TEXTURE_HEIGHT);
+                    _backgroundTexturePixels = new Color32[BACKGROUND_TEXTURE_PIXELS_COUNT];
+                    _backgroundTexture.SetPixels32(_backgroundTexturePixels);
+                    _backgroundTexture.Apply();
+                }
+                
+                public IGizmoRenderer<TextGizmo> RegisterNewRenderer() { return new Renderer(); }
+
+                #region Renderer
+                private class Renderer : IGizmoRenderer_UnityGizmos<TextGizmo>
+                {
+                    private static GUIStyle _labelStyle;
+                    private static GUIContent _labelDummy;
+                    public int ExecuteOrder => default(UnlitMat).GetExecuteOrder();
+                    public bool IsStaticRender => false;
+                    public void Prepare(Camera camera, GizmosList<TextGizmo> list) { }
+                    public void Render(Camera camera, GizmosList<TextGizmo> list, CommandBuffer cb) { }
+                    public void Render_UnityGizmos(Camera camera, GizmosList<TextGizmo> list)
+                    {
+#if UNITY_EDITOR
+                        Color defaultColor = GUI.color;
+                        if (_labelStyle == null || _labelDummy == null)
+                        {
+                            _labelStyle = GUI.skin.label;
+                            _labelStyle.richText = false;
+                            _labelDummy = new GUIContent();
+                        }
+                        Handles.BeginGUI();
+                        foreach (ref readonly var item in list)
+                        {
+                            GUI.color = item.Color * GlobalColor;
+                            _labelDummy.text = item.Value.TextBuilderInstance.Text.ToString();
+
+                            if (item.Value.TextBuilderInstance.UseWorldScale) {
+                                var zoom = 1f;
+
+                                var cam = GetCurrentCamera();
+                                if (cam != null) {
+                                    zoom = cam.orthographicSize;
+                                } else {
+                                    var currentDrawingSceneView = SceneView.currentDrawingSceneView;
+                                    
+                                    if (currentDrawingSceneView != null
+                                        && SceneView.currentDrawingSceneView.camera != null) {
+                                        cam = currentDrawingSceneView.camera;
+                                    
+                                        if (camera != null) {
+                                            zoom = cam.orthographicSize;
+                                        }
+                                    }
+                                }
+                                
+                                _labelStyle.fontSize = Mathf.FloorToInt(item.Value.TextBuilderInstance.FontSize / zoom);
+                            } else {
+                                _labelStyle.fontSize = item.Value.TextBuilderInstance.FontSize;
+                            }
+                            
+                            _labelStyle.alignment = item.Value.TextBuilderInstance.TextAnchor;
+
+                            _labelStyle.normal = new GUIStyleState {
+                                textColor = item.Color * GlobalColor,
+                            };
+                            
+                            if (item.Value.TextBuilderInstance.UseBackground) {
+                                for (int i = 0; i < BACKGROUND_TEXTURE_PIXELS_COUNT; i++) {
+                                    _backgroundTexturePixels[i] = item.Value.TextBuilderInstance.BackgroundColor;
+                                }
+
+                                _backgroundTexture.SetPixels32(_backgroundTexturePixels);
+                                _backgroundTexture.Apply();
+
+                                _labelStyle.normal.background = _backgroundTexture;
+                            }
+                            
+                            if (!(HandleUtility.WorldToGUIPointWithDepth(item.Value.TextBuilderInstance.Position).z < 0f))
+                            {
+                                GUI.Label(HandleUtility.WorldPointToSizedRect(item.Value.TextBuilderInstance.Position, _labelDummy, _labelStyle), _labelDummy, _labelStyle);
+                            }
+                        }
+                        Handles.EndGUI();
+                        GUI.color = defaultColor;
+#endif
+                    }
+                }
+                #endregion
+            }
+            #endregion
+            
+            #region TextBuilder
+            /// <summary>
+            /// Set text gizmos instance settings using a builder pattern. 
+            /// </summary>
+            public struct TextBuilder {
+                private const TextAnchor DEFAULT_TEXT_ANCHOR = TextAnchor.MiddleLeft;
+                private const int DEFAULT_FONT_SIZE = 16;
+                
+                /// <summary>
+                /// Text world position.
+                /// </summary>
+                public Vector3 Position { get; set; }
+                
+                /// <summary>
+                /// Text. Uses ToString() of the passed object. 
+                /// </summary>
+                public object Text { get; set; }
+
+                /// <summary>
+                /// Font size. Default is <see cref="DEFAULT_FONT_SIZE" />.
+                /// </summary>
+                public int FontSize { get; set; }
+                
+                /// <summary>
+                /// Text alignment. Default is <see cref="DEFAULT_TEXT_ANCHOR" />.
+                /// </summary>
+                public TextAnchor TextAnchor { get; set; }
+                
+                /// <summary>
+                /// Background texture color.
+                /// </summary>
+                public Color BackgroundColor { get; set; }
+                
+                /// <summary>
+                /// Flag to use background texture and background color when rendering text gizmo instance.
+                /// </summary>
+                public bool UseBackground { get; set; }
+                
+                /// <summary>
+                /// If set true - camera zooming will affect text scale to keep same size in the world.
+                /// </summary>
+                public bool UseWorldScale { get; set; }
+
+                public TextBuilder(Vector3 position, object text, int fontSize = DEFAULT_FONT_SIZE, TextAnchor textAnchor = DEFAULT_TEXT_ANCHOR) : this() {
+                    Position = position;
+                    Text = text;
+                    FontSize = fontSize;
+                    TextAnchor = textAnchor;
+                }
+
+                public TextBuilder SetPosition(Vector3 position) {
+                    Position = position;
+                    return this;
+                }
+                    
+                public TextBuilder SetText(object text) {
+                    Text = text;
+                    return this;
+                }
+                    
+                public TextBuilder SetFontSize(int fontSize) {
+                    FontSize = fontSize;
+                    return this;
+                }
+                    
+                public TextBuilder SetTextAnchor(TextAnchor textAnchor) {
+                    TextAnchor = textAnchor;
+                    return this;
+                }
+
+                public TextBuilder SetBackground(Color backgroundColor) {
+                    UseBackground = true;
+                    BackgroundColor = backgroundColor;
+                    return this;
+                }
+                    
+                public TextBuilder RemoveBackground() {
+                    UseBackground = false;
+                    return this;
+                }
+                
+                public TextBuilder SetWorldScaling() {
+                    UseWorldScale = true;
+                    return this;
+                }
+                    
+                public TextBuilder RemoveWorldScaling() {
+                    UseWorldScale = false;
+                    return this;
+                }
+            }
+            #endregion
+        }
+    }
+}

--- a/Runtime/Gizmos/DebugX.text.cs
+++ b/Runtime/Gizmos/DebugX.text.cs
@@ -95,35 +95,22 @@ namespace DCFApixels {
                             _labelStyle.richText = false;
                             _labelDummy = new GUIContent();
                         }
+
+                        if (list.Count == 0) {
+                            return;
+                        }
+
+                        var zoom = GetCameraZoom();
+                        
                         Handles.BeginGUI();
                         foreach (ref readonly var item in list)
                         {
                             GUI.color = item.Color * GlobalColor;
                             _labelDummy.text = item.Value.TextBuilderInstance.Text.ToString();
 
-                            if (item.Value.TextBuilderInstance.UseWorldScale) {
-                                var zoom = 1f;
-
-                                var cam = GetCurrentCamera();
-                                if (cam != null) {
-                                    zoom = cam.orthographicSize;
-                                } else {
-                                    var currentDrawingSceneView = SceneView.currentDrawingSceneView;
-                                    
-                                    if (currentDrawingSceneView != null
-                                        && SceneView.currentDrawingSceneView.camera != null) {
-                                        cam = currentDrawingSceneView.camera;
-                                    
-                                        if (camera != null) {
-                                            zoom = cam.orthographicSize;
-                                        }
-                                    }
-                                }
-                                
-                                _labelStyle.fontSize = Mathf.FloorToInt(item.Value.TextBuilderInstance.FontSize / zoom);
-                            } else {
-                                _labelStyle.fontSize = item.Value.TextBuilderInstance.FontSize;
-                            }
+                            _labelStyle.fontSize = item.Value.TextBuilderInstance.UseWorldScale 
+                                ? Mathf.FloorToInt(item.Value.TextBuilderInstance.FontSize / zoom) 
+                                : item.Value.TextBuilderInstance.FontSize;
                             
                             _labelStyle.alignment = item.Value.TextBuilderInstance.TextAnchor;
 
@@ -149,6 +136,29 @@ namespace DCFApixels {
                         }
                         Handles.EndGUI();
                         GUI.color = defaultColor;
+
+                        float GetCameraZoom() {
+                            const float DEFAULT_ZOOM = 1f;
+                        
+                            var localCamera = GetCurrentCamera();
+                            if (localCamera != null) {
+                                return localCamera.orthographicSize;
+                            }
+                            
+                            var currentDrawingSceneView = SceneView.currentDrawingSceneView;
+
+                            if (currentDrawingSceneView == null) {
+                                return DEFAULT_ZOOM;
+                            }
+                            
+                            localCamera = currentDrawingSceneView.camera;
+                                
+                            if (camera != null) {
+                                return localCamera.orthographicSize;
+                            }
+
+                            return DEFAULT_ZOOM;
+                        }
 #endif
                     }
                 }


### PR DESCRIPTION
Перевёл настройки на паттерн билдера, чтобы надёжнее сетить булки, при помощи которых сокращаются операции на неиспользуемых фичах.

**Добавленные фичи:**
- Изменение размера шрифта.
- Выбор типа выравнивания текста (TextAnchor).
- Возможность установить задний цвет. 
- Возможность скейлить текст по зуму (размеру) камеры, чтобы сохранять размер текста по отношению к игровому миру.

**Нужно проверить:**
- [ ] Момент с кешированием и переиспользованием текстуры, нужно и возможно-ли её где-то уничтожать при перезагрзке домена.
- [ ] Инлайны и прочие оптимизации компилятора, за которые я лично не шарю.
- [ ] Возможно лишний поиск камеры в SceneView. 